### PR TITLE
Added missing dependency xrandr.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ A rice inspired by `NieR:Automata` ui
     - ### Dependancies
         #### Arch
         > ```sh
-        > paru -S hyprland-git foot grim swww-git fish theme.sh aylurs-gtk-shell-git sassc starship cava imagemagick hyprland-plugin-hyprbars-git gnome-bluetooth wl-clipboard libdbusmenu-gtk3 gnome-bluetooth-3.0 nerd-fonts
+        > paru -S hyprland-git foot grim swww-git fish theme.sh aylurs-gtk-shell-git sassc starship cava imagemagick hyprland-plugin-hyprbars-git gnome-bluetooth wl-clipboard libdbusmenu-gtk3 gnome-bluetooth-3.0 xorg-xrandr nerd-fonts
         > ```
         #### STTT
         > install from https://github.com/flick0/sttt


### PR DESCRIPTION
I have noticed, that in last changes, some files use xrandr, which is not installed by default. So I think, it would be good to include it to dependencies as well.